### PR TITLE
2.0.0 beta.5 updated fork

### DIFF
--- a/addon/mixins/table-header.js
+++ b/addon/mixins/table-header.js
@@ -137,10 +137,11 @@ export default Mixin.create({
   }).readOnly(),
 
   style: computed('sharedOptions.occlusion', function() {
-    if (this.get('sharedOptions.occlusion')) {
-      const scrollbarThickness = this.get('scrollbarThickness.thickness');
-      return cssStyleify({ paddingRight: `${scrollbarThickness}px` });
-    }
+    // if (this.get('sharedOptions.occlusion')) {
+    //   const scrollbarThickness = this.get('scrollbarThickness.thickness');
+    //   return cssStyleify({ paddingRight: `${scrollbarThickness}px` });
+    // }
+    return '';
   }).readOnly(),
 
   init() {

--- a/addon/templates/components/lt-body.hbs
+++ b/addon/templates/components/lt-body.hbs
@@ -36,6 +36,11 @@
                        canSelect=canSelect
                        click=(action "onRowClick" row)
                        doubleClick=(action "onRowDoubleClick" row)}}
+              {{yield (hash
+                      expanded-row=(component lt.spanned-row classes='lt-expanded-row' colspan=colspan yield=row visible=row.expanded)
+                      loader=(component lt.spanned-row visible=false)
+                      no-data=(component lt.spanned-row visible=false)
+                    ) rows}}
             {{/vertical-collection}}
             {{yield (hash
                       loader=(component lt.spanned-row classes="lt-is-loading")


### PR DESCRIPTION
Going to keep this as a branch / PR for now.

It's a branch off latest ELT 2.0.0-beta.5, but with these fixes;
* fixes header padding when occlusion enabled https://github.com/offirgolan/ember-light-table/issues/554 and https://github.com/offirgolan/ember-light-table/issues/487
  * just comments out the `paddingRight` code in mixins/table-header.js
* fixes expanded rows when occlusion enabled https://github.com/offirgolan/ember-light-table/pull/687

(note, I don't seem to have permission to update Blake's ELT fork, so I haven't been able to update the 2-x branch to latest, so this PR looks massive)